### PR TITLE
add option to evaluate API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip3 install youterm
 
 Invoking `youterm` with no flags defaults to audio only. Below the usage:
 ```
-usage: youterm [-h] [-v] [-r <n>] [-a <api_key>]
+usage: youterm [-h] [-v] [-r <n>] [-a <api_key>] [-k <cmd>]
 
 CLI tool to search for YouTube videos and play selected video/audio via MPV
 
@@ -55,4 +55,6 @@ options:
                         Number of search results displayed
   -a <api_key>, --api <api_key>
                         YouTube Data v3 API key
+  -k <cmd>, --key-cmd <cmd>
+                        Command to evaluate API key
 ```

--- a/src/youterm/__main__.py
+++ b/src/youterm/__main__.py
@@ -135,8 +135,16 @@ def main() -> None:
         metavar=("<api_key>"),
         help="YouTube Data v3 API key",
     )
+    argparser.add_argument(
+        "-k",
+        "--key-cmd",
+        type=str,
+        default="pass show api/youtube",
+        metavar=("<cmd>"),
+        help="Command to evaluate API key",
+    )
     args = argparser.parse_args()
-    key = args.api or get_api_key()
+    key = args.api or get_api_key(args.key_cmd)
     video_fmt = ""
     results = 5  # default value
     if args.video:

--- a/src/youterm/yt.py
+++ b/src/youterm/yt.py
@@ -20,9 +20,6 @@ from requests import get
 from youterm.date import format_date
 
 
-PASS_ENTRY = "api/youtube"
-
-
 def get_api_key(key_cmd: str) -> str:
     key = popen(key_cmd).read().strip()
     if not key:  # handling no key in password store

--- a/src/youterm/yt.py
+++ b/src/youterm/yt.py
@@ -23,10 +23,10 @@ from youterm.date import format_date
 PASS_ENTRY = "api/youtube"
 
 
-def get_api_key() -> str:
-    key = popen(f"pass show {PASS_ENTRY}").read().strip()
+def get_api_key(key_cmd: str) -> str:
+    key = popen(key_cmd).read().strip()
     if not key:  # handling no key in password store
-        exit("Error occoured retrieving api key")
+        exit("Error occured retrieving api key")
     return key
 
 


### PR DESCRIPTION
Useful to specify one's own way to get the key, including pass with a different path.